### PR TITLE
Implement Default in all cases where S: Default

### DIFF
--- a/src/iter/ref_mut.rs
+++ b/src/iter/ref_mut.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::VecDeque,
-    hash::{BuildHasher, Hash},
-};
+use std::hash::{BuildHasher, Hash};
 
 use gat_lending_iterator::LendingIterator;
 
@@ -10,7 +7,7 @@ use crate::{mut_guard::MutGuard, ExtractKey, ExtractMap};
 #[must_use = "Iterators do nothing if not consumed"]
 pub struct IterMut<'a, K, V, S> {
     map: &'a mut ExtractMap<K, V, S>,
-    keys: VecDeque<K>,
+    keys: Vec<K>,
 }
 
 impl<K, V: std::fmt::Debug, S> std::fmt::Debug for IterMut<'_, K, V, S> {
@@ -40,7 +37,7 @@ where
     type Item<'item> = MutGuard<'item, K, V, S> where Self: 'item;
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
-        let key = self.keys.pop_front()?;
+        let key = self.keys.pop()?;
         self.map.get_mut(&key)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,9 @@ pub struct ExtractMap<K, V, S = RandomState> {
     build_hasher: S,
 }
 
-impl<K, V> Default for ExtractMap<K, V, RandomState> {
+impl<K, V, S> Default for ExtractMap<K, V, S> where S:Default{
     fn default() -> Self {
-        Self::new()
+        Self::with_hasher(S::default())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub struct ExtractMap<K, V, S = RandomState> {
     build_hasher: S,
 }
 
-impl<K, V, S> Default for ExtractMap<K, V, S> where S:Default{
+impl<K, V, S: Default> Default for ExtractMap<K, V, S> {
     fn default() -> Self {
         Self::with_hasher(S::default())
     }


### PR DESCRIPTION
Ran into this trying to move all of the extractmaps used in the serenity model + cache to use a better hasher for the purpose at hand. This shouldn't be breaking so a patch should be fine according to cargo-semver since this crate is < 1.x.x.